### PR TITLE
Lean on goreleaser for docker builds; upgrade it too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,10 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
 
     permissions:
       contents: write
+      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -32,26 +33,6 @@ jobs:
           go-version-file: go.mod
           check-latest: true
           cache: true
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAP_GITHUB_TOKEN: ${{ secrets.TAP }}
-
-  build-and-push-image:
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -66,10 +47,14 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP }}
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE: ${{ env.IMAGE_NAME }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,6 @@
 ---
+version: 2
+
 before:
   hooks:
     - go mod tidy
@@ -19,6 +21,7 @@ builds:
       - -trimpath
     ldflags:
       - -s -w -X main.version={{.Version}}
+    mod_timestamp: "{{ .CommitTimestamp }}"
     tags:
       - netgo
 
@@ -27,7 +30,7 @@ brews:
     ids:
       - archives
     homepage: "https://github.com/kgaughan/nibbled"
-    tap:
+    repository:
       owner: kgaughan
       name: homebrew-tap
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
@@ -80,8 +83,16 @@ nfpms:
     formats:
       - rpm
 
+dockers:
+  - image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE }}:{{ .Tag }}"
+    skip_push: auto
+    use: buildx
+    dockerfile: Dockerfile
+
 checksum:
-  name_template: "checksums.txt"
+  algorithm: sha256
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
 
 snapshot:
   name_template: "{{ incpatch .Version }}-next"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,3 @@
-FROM golang:1.16 AS builder
-
-ENV GOPATH /go
-ENV APPPATH /repo
-COPY . /repo
-RUN cd /repo && CGO_ENABLED=0 go build -tags netgo -trimpath -ldflags '-s -w' -o nibbled .
-
 FROM alpine:latest
-COPY --from=builder /repo/nibbled /nibbled
+COPY nibbled .
 ENTRYPOINT ["/nibbled"]

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module nibbled
+module github.com/kgaughan/nibbled
 
 go 1.18
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the CI workflows to leverage GoReleaser for Docker builds and releases, upgrades GoReleaser to version 2, and adds Dependabot configuration for automated dependency updates. Additionally, it includes minor enhancements to the GoReleaser configuration and updates permissions in the build and lint workflows.

- **Enhancements**:
    - Upgraded GoReleaser to version 2 and updated its configuration to use the new version.
    - Modified GoReleaser configuration to include Docker image building and pushing with buildx.
- **CI**:
    - Updated GitHub Actions workflows to use GoReleaser for Docker builds and releases.
    - Added permissions for contents and pull-requests in build and lint workflows.
- **Chores**:
    - Added Dependabot configuration for automated dependency updates.
    - Updated module path in go.mod to use the GitHub repository URL.

<!-- Generated by sourcery-ai[bot]: end summary -->