### PR TITLE
Add latest tag to future images

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -86,6 +86,7 @@ nfpms:
 dockers:
   - image_templates:
       - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE }}:{{ .Tag }}"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE }}:latest"
     skip_push: auto
     use: buildx
     dockerfile: Dockerfile


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the .goreleaser.yaml configuration to add a 'latest' tag to Docker image templates, ensuring that the most recent image is always tagged as 'latest'.

- **Deployment**:
    - Added 'latest' tag to Docker image templates in .goreleaser.yaml to ensure the most recent image is tagged as 'latest'.

<!-- Generated by sourcery-ai[bot]: end summary -->